### PR TITLE
fix: remove context message, standardize names, and  reorder tabs

### DIFF
--- a/toolbox/fdc3-workbench/src/App.tsx
+++ b/toolbox/fdc3-workbench/src/App.tsx
@@ -202,18 +202,20 @@ export const App = observer(() => {
 										indicator: classes.indicator,
 									}}
 								>
+									
+									<Tab label="Contexts" />
+									<Tab label="Intents" />
 									<Tab label="System Channels" />
-									<Tab label="Context" />
-									<Tab label="Intent" />
+									<Tab label="App Channels" />
 								</Tabs>
 								<TabPanel value={tabIndex} index={0}>
-									<Channels />
-								</TabPanel>
-								<TabPanel value={tabIndex} index={1}>
 									<ContextCreate />
 								</TabPanel>
-								<TabPanel value={tabIndex} index={2}>
+								<TabPanel value={tabIndex} index={1}>
 									<Intents />
+								</TabPanel>
+								<TabPanel value={tabIndex} index={2}>
+									<Channels />
 								</TabPanel>
 							</Paper>
 						</Grid>

--- a/toolbox/fdc3-workbench/src/components/ContextCreate.tsx
+++ b/toolbox/fdc3-workbench/src/components/ContextCreate.tsx
@@ -163,19 +163,6 @@ export const ContextCreate = observer(() => {
 			// 	id: "empty",
 			// 	template: null,
 			// });
-			systemLogStore.addLog({
-				name: "createContext",
-				type: "success",
-				value: context?.id,
-				variant: "text",
-			});
-		} else {
-			systemLogStore.addLog({
-				name: "createContext",
-				type: "error",
-				value: context?.id,
-				variant: "text",
-			});
 		}
 	};
 
@@ -216,7 +203,7 @@ export const ContextCreate = observer(() => {
 			});
 		} else {
 			systemLogStore.addLog({
-				name: "createContext",
+				name: "saveTemplate",
 				type: "success",
 				value: undefined,
 				variant: "text",

--- a/toolbox/fdc3-workbench/src/fixtures/logMessages.ts
+++ b/toolbox/fdc3-workbench/src/fixtures/logMessages.ts
@@ -64,10 +64,6 @@ export const getLogMessage = (name: logMessagesName, type: logMessagesType, valu
 			info: `Received context via '[${value}]' listener.`,
 			error: `Failed to receive context from '[${value}]' listener.`,
 		},
-		createContext: {
-			success: `Set my current context to type '[${value}]'.`,
-			error: `Failed to set my current context to type '[${value}]'.`,
-		},
 		saveTemplate: {
 			success: `Saved context template for '[${value}]'.`,
 			error: `Failed to save context template.`,

--- a/toolbox/fdc3-workbench/src/store/SystemLogStore.ts
+++ b/toolbox/fdc3-workbench/src/store/SystemLogStore.ts
@@ -18,7 +18,6 @@ export type logMessagesName =
 	| "removeIntentListener"
 	| "receivedContextListener"
 	| "receivedIntentListener"
-	| "createContext"
 	| "saveTemplate"
 	| "copyToClipboard";
 


### PR DESCRIPTION
1. Context validation and alert box messages need correcting
2. Standardize pluralization of tab names
3. Reorder left hand panel tabs