### PR TITLE
49663 FDC3 Workbench: fix localstorage retrieval

### DIFF
--- a/toolbox/fdc3-workbench/src/store/ContextStore.ts
+++ b/toolbox/fdc3-workbench/src/store/ContextStore.ts
@@ -46,9 +46,23 @@ class ContextStore {
 			addContextListener: action,
 			removeContextListener: action,
 		});
-		const localStorageContextList = localStorage.getItem("contextList")
-		if(localStorageContextList) this.contextsList = JSON.parse(localStorageContextList)
-		else this.updateLocalStorage(JSON.stringify(this.contextsList))
+		const localStorageContextList = localStorage.getItem("contextList");
+		let usingDefaultContexts = true;
+		try {
+			if(localStorageContextList)
+			{
+				const parsedListFromStorage = JSON.parse(localStorageContextList);
+				if (Array.isArray(parsedListFromStorage)){
+					this.contextsList = parsedListFromStorage;
+					usingDefaultContexts = false;
+				}
+			}
+		} catch (err){
+			console.log("Failed to parse context list from localstorage");
+		}
+		if (usingDefaultContexts) {
+			this.updateLocalStorage(JSON.stringify(contexts));
+		}
 	}
 
 	addContextItem(contextItem: ContextItem) {


### PR DESCRIPTION
I had an issue when running this against a clear cache - `contextLists` was not an array. Seems worth tightening up the storage retrieval in case you get something back but it won't parse or parses as something other than an array.